### PR TITLE
SetupWizard: Conditionally run account setup

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="default_theme_name" translatable="false">Material</string>
 
     <string name="cm_account_type" translatable="false">com.cyanogenmod.account</string>
+    <string name="cm_account_package_name" translatable="false">com.cyanogenmod.account</string>
 
     <string name="next">Next</string>
     <string name="skip">Skip</string>

--- a/src/com/cyanogenmod/setupwizard/setup/CMSetupWizardData.java
+++ b/src/com/cyanogenmod/setupwizard/setup/CMSetupWizardData.java
@@ -26,6 +26,7 @@ import android.telephony.TelephonyManager;
 
 import android.util.Log;
 import com.android.internal.telephony.TelephonyIntents;
+import com.cyanogenmod.setupwizard.R;
 import com.cyanogenmod.setupwizard.util.SetupWizardUtils;
 
 import java.util.ArrayList;
@@ -66,7 +67,9 @@ public class CMSetupWizardData extends AbstractSetupData {
         if (SetupWizardUtils.hasGMS(mContext)) {
             pages.add(new GmsAccountPage(mContext, this).setHidden(true));
         }
-        if (!SetupWizardUtils.hasLeanback(mContext)) {
+        if (!SetupWizardUtils.hasLeanback(mContext) &&
+                SetupWizardUtils.isPackageInstalled(mContext,
+                    mContext.getString(R.string.cm_account_package_name))) {
             pages.add(new CyanogenServicesPage(mContext, this).setHidden(true));
         }
         if (SetupWizardUtils.hasFingerprint(mContext) && SetupWizardUtils.isOwner()) {

--- a/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
+++ b/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
@@ -199,6 +199,16 @@ public class SetupWizardUtils {
         return AccountManager.get(context).getAccountsByType(accountType).length > 0;
     }
 
+    public static boolean isPackageInstalled(Context context, String packageName) {
+        PackageManager pm = context.getPackageManager();
+        try {
+            pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
     public static void disableSetupWizard(Context context) {
         disableComponent(context, context.getPackageName(),
                 "com.cyanogenmod.setupwizard.ui.SetupWizardActivity");


### PR DESCRIPTION
If the package defined by cm_account_type (which can be overlayed)
exists, then add CyanogenSettingsPage. Otherwise, omit.

PS3: On the cyngn side, the account type and package name don't match. Added a new string to overlay.

Change-Id: I15e032e21281aaf51ca32ac9cc0861e033201f19
